### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "node": ">=0.10.33"
   },
   "dependencies": {
-    "semver": "^2.3.1",
-    "useragent": "2.0.x"
+    "semver": "*",
+    "useragent": "2.x.x"
   },
   "peerDependencies": {
     "hapi": ">=8.x.x"


### PR DESCRIPTION
If semver is followed, I don't see any reason to limit `useragent` to 2.0.x.
`semver` is set to `*` since `useragent` needs it but we'll never actually use it.
