### PR TITLE
4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scooter",
   "description": "User-agent information plugin for hapi",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "contributors": [],
   "repository": "git://github.com/hapijs/scooter",
   "main": "lib/index.js",


### PR DESCRIPTION
version bump

now uses 4.x syntax with const etc so this is a breaking change.