### PR TITLE
Support for hapi v21, node v18, ESM tests, multiple registration

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,3 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2013-2020, Sideway Inc, and project contributors  
-Copyright (c) 2013-2014, Walmart.  
+Copyright (c) 2013-2022, Project contributors
+Copyright (c) 2013-2020, Sideway Inc
+Copyright (c) 2013-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const Useragent = require('useragent');
 
+// Requires semver be installed
 require('useragent/features');                      // Enhances Useragent
 
 
@@ -10,8 +11,9 @@ const internals = {};
 
 exports.plugin = {
     pkg: require('../package.json'),
+    once: true,
     requirements: {
-        hapi: '>=18.4.0'
+        hapi: '>=20.0.0'
     },
     register: function (server, options) {
 

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     ]
   },
   "dependencies": {
-    "semver": "7.x.x",
-    "useragent": "2.x.x"
+    "semver": "^7.3.8",
+    "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Scooter;
+
+    before(async () => {
+
+        Scooter = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Scooter)).to.equal([
+            'default',
+            'plugin'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,13 @@ const expect = Code.expect;
 
 describe('scooter', () => {
 
+    it('may be registered multiple times', async () => {
+
+        const server = new Hapi.Server();
+        await server.register(Scooter);
+        await expect(server.register(Scooter)).not.to.reject();
+    });
+
     it('parses and sets user-agent information for an incoming request', async () => {
 
         const server = new Hapi.Server();

--- a/test/index.js
+++ b/test/index.js
@@ -17,14 +17,14 @@ describe('scooter', () => {
 
     it('may be registered multiple times', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
         await server.register(Scooter);
         await expect(server.register(Scooter)).not.to.reject();
     });
 
     it('parses and sets user-agent information for an incoming request', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
         await server.register(Scooter);
 
         server.route({ method: 'GET', path: '/', handler: (request, h) => request.plugins.scooter.os.family });


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19 and below.
 - Support and test on node v18.
 - Update all deps for node v18 and hapi v21.
 - Allow plugin to be registered multiple times.
 - Test ESM support.

If this looks good, this will go out as scooter v7.
