### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hapi/scooter",
   "description": "User-agent information plugin for hapi",
   "version": "8.0.0",
-  "repository": "git://github.com/hapijs/scooter",
+  "repository": "https://github.com/hapijs/scooter",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- update the package repository URL to use HTTPS instead of the legacy git protocol

## Validation
- git diff --check
- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'